### PR TITLE
Changed main link to BitBucket repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 Orthanc Downloads
 =================
 
-Orthanc is a lightweight DICOM server for medical imaging.
+Orthanc is a lightweight DICOM server for medical imaging. You can find more information about [Orthanc at its official homepage](http://www.orthanc-server.com/download.php).
 
 The only purpose of this GitHub repository is to ship the releases of Orthanc for Linux packages.
 
-Please go to the [official homepage of Orthanc](http://www.orthanc-server.com/download.php).
+You can find the [official source code repository at BitBucket](https://bitbucket.org/sjodogne/orthanc/src)
+

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Orthanc Downloads
 =================
 
-Orthanc is a lightweight DICOM server for medical imaging. You can find more information about [Orthanc at its official homepage](http://www.orthanc-server.com/download.php).
+[Orthanc] (http://www.orthanc-server.com/download.php) is a lightweight DICOM server for medical imaging.
 
 The only purpose of this GitHub repository is to ship the releases of Orthanc for Linux packages.
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Orthanc Downloads
 =================
 
-[Orthanc] (http://www.orthanc-server.com/download.php) is a lightweight DICOM server for medical imaging.
+[Orthanc](http://www.orthanc-server.com/download.php) is a lightweight DICOM server for medical imaging.
 
 The only purpose of this GitHub repository is to ship the releases of Orthanc for Linux packages.
 


### PR DESCRIPTION
If people find this repo, they were probably looking for Orthanc's source code, so I changed the focus of the readme to point people towards the BitBucket repo.